### PR TITLE
v1.0.3.9005

### DIFF
--- a/R/getUSGSflow.R
+++ b/R/getUSGSflow.R
@@ -38,7 +38,7 @@ getUSGSflow <- function(siteNumber, yearStart, yearEnd, fill=TRUE,
 
 # -----< Change history >--------------------------------------------
 # 10May2018: JBH: fill in beginning/ending NAs (currently written to
-#                 fill in *all* begin/end NAs. need to migrate to max.fill)
+#                 fill in *all* begin/end NAs. need to migrate to max.fill) 
 # 24Nov2017: JBH: transitioned to internalized smwrBase functions
 
 # fill=TRUE; span=10; max.fill=10; siteNumber=usgsGageID[1]


### PR DESCRIPTION
updated getUSGSflow function to fill in missing flow values at the beginning and ending of time series. (will need additional work to migrate to only fill in values up to a gap of max.fill, but then also move the max.fill argument so that it is exposed to user selection).